### PR TITLE
Create middleware isAdmin for create course route protection

### DIFF
--- a/backend/middlewares/authMiddleware.js
+++ b/backend/middlewares/authMiddleware.js
@@ -37,4 +37,12 @@ const protect = async (req, res, next) => {
   }
 };
 
-module.exports = { protect };
+const isAdmin = (req, res, next) => {
+  if (req.user && req.user.role === "admin") {
+    next(); // User is admin, continue
+  } else {
+    return res.status(403).json({ message: "Access denied, admin only" });
+  }
+};
+
+module.exports = { protect, isAdmin };

--- a/backend/routes/courseRoutes.js
+++ b/backend/routes/courseRoutes.js
@@ -1,5 +1,6 @@
 const express = require("express");
 const router = express.Router();
+const { protect, isAdmin } = require("../middlewares/authMiddleware");
 
 const {
   getAllCourses,
@@ -81,6 +82,6 @@ router.get("/:id", getCourseById);
  *         description: Invalid input
  */
 
-router.post("/", createCourse);
+router.post("/", protect, isAdmin, createCourse);
 
 module.exports = router;


### PR DESCRIPTION
### Summary of the Pull Request -:

### In this Pull Request -:

- Create Middleware isAdmin in authMiddleware to ensure only Admin can create a course.
- Protect route for create a course with protect and isAdmin middlewares.
- Only logged in user with Admin role can create a course.
- Tested the API endpoints and route protected on Thunder client, it is working as expected.